### PR TITLE
filter out HTML comments

### DIFF
--- a/search
+++ b/search
@@ -16,6 +16,7 @@ url="$(printf 'http://www.google.com/search?hl=&q=%s&start=0&sa=N&num=10&ie=UTF-
 
 curl -A "$useragent" --header "$header" --location "$url" 2>/dev/null |
     hxnormalize -x -l 1000 2>/dev/null |
+    sed -e :a -re 's/<!.*?>//g;/<!--/N;//ba' |
     hxselect -i -s '|||' '.g' |
     tr '\n' ' ' |
     sed $'s/|||/\\\n/g' |


### PR DESCRIPTION
Executions of the search script all start with the following output:
	1: syntax error

This happens because hxnormalize doesn't touch HTML comments, while hxselect
doesn't know how to deal with them. Google documents all start with a DOCTYPE
clause, which reaches hxselect, that doesn't know what do do with it, claiming
a syntax error.

This patch filters out all "<! something >" strings from the document, avoiding
the syntax error message.