### PR TITLE
Display a followable link, not a readable one

### DIFF
--- a/search
+++ b/search
@@ -27,9 +27,9 @@ curl -A "$useragent" --header "$header" --location "$url" 2>/dev/null |
         title="$(echo $result |
             hxselect -c h3 a |
             sed -e 's/<b>//g' -e 's|</b>||g' )"
-        link="$(echo $result | hxselect -c 'cite' |
-            sed 's/<\\?b>//g' |
-            sed -e 's/<b>//g' -e 's|</b>||g' )"
+        link="$(echo $result | hxselect 'a' | cut -d\" -f2 |
+            cut -d= -f2 |
+            cut -d\& -f1)"
         meta="$(echo $result |
             hxselect -c .st |
             hxremove span.f |


### PR DESCRIPTION
Google results point to an URL, and displays it. But when the URL is too long,
they display a "beautified version" of it: for instance,

http://superuser.com/questions/47192/google-search-from-linux-terminal
which is a long URL, is simply displayed as
superuser.com/questions/.../google-search-from-linux-terminal

While this is pretty, this isn't useful on a CLI tool: if you want to act upon
a certain result, you'll need the complete URL, not a prettified but lossy
version of it.

The search tool was showing the "display version" of the link instead of the
actual link, this patch changes that.