### PR TITLE
Add the option of having no colors in the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ brew install curl html-xml-utils
 </code>
 </pre>
 
+If you wan't want color on the output, you can set the NOCOLOR variable:
+<code>
+NOCOLOR=1 ./search Ilari Mäkelä
+</code>
+</pre>

--- a/search
+++ b/search
@@ -30,14 +30,27 @@ curl -A "$useragent" --header "$header" --location "$url" 2>/dev/null |
         link="$(echo $result | hxselect -c 'cite' |
             sed 's/<\\?b>//g' |
             sed -e 's/<b>//g' -e 's|</b>||g' )"
-        meta="$(echo $result |
-            hxselect -c .st |
-            hxremove span.f |
-            hxunent |
-            sed -e 's/<b>/\\033[1m/g' -e 's|</b>|\\033[0m|g' )"
+ 
+        if [ -z "${NOCOLOR+x}" ]
+        then
+            meta="$(echo $result |
+                hxselect -c .st |
+                hxremove span.f |
+                hxunent |
+                sed -e 's/<b>/\\033[1m/g' -e 's|</b>|\\033[0m|g' )"
 
-        echo -e "\033[34m$title\033[0m"
-        echo -e "\033[32m$link\033[0m"
+            echo -e "\033[34m$title\033[0m"
+            echo -e "\033[32m$link\033[0m"
+        else
+            meta="$(echo $result |
+                hxselect -c .st |
+                hxremove span.f |
+                hxunent |
+                sed -e 's/<b>//g' -e 's|</b>||g' )"
+
+            echo -e "$title"
+            echo -e "$link"
+        fi
         echo -e "$meta" | \
            fold -w 80 -s
         echo


### PR DESCRIPTION
If you set up the NOCOLOR variable, eg. by executing the script like
	NOCOLOR=1 ./search string
the output will be colorless.

This might be particularly interesting in cases where the output of
search is meant to be machine-readable.